### PR TITLE
adding `.jslintrc` file

### DIFF
--- a/.jslintrc
+++ b/.jslintrc
@@ -1,0 +1,6 @@
+{
+  "node": true,
+  "predef": {
+		"atom": true
+	}
+}

--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -1,4 +1,3 @@
-/*globals require, module, atom*/
 "use strict";
 
 var View = require('atom').View,

--- a/lib/MessagePanelView.js
+++ b/lib/MessagePanelView.js
@@ -1,4 +1,3 @@
-/*globals require, module, atom*/
 "use strict";
 
 var View = require('atom').View,

--- a/lib/PlainMessageView.js
+++ b/lib/PlainMessageView.js
@@ -1,4 +1,3 @@
-/*globals require, module, atom*/
 "use strict";
 
 var View = require('atom').View,


### PR DESCRIPTION
lets tell jslint that we are running node, so we can remove all the
globals and all the “”Use the function form of "use strict" [issues](https://scrutinizer-ci.com/g/tcarlsen/atom-message-panel/inspec
tions/7d995b42-cd51-49c3-8ebc-22a8d88133ea/issues/)
