### PR TITLE
foldmode "line errors" is no longer clickable

### DIFF
--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -2,7 +2,8 @@
 
 var
   View = require('atom').View,
-  inherits = require('./utils').inherits;
+  inherits = require('./utils').inherits,
+  $ = require('atom').$;
 
 var LineMessageView = function (params) {
   this.line = params.line;
@@ -68,8 +69,14 @@ LineMessageView.prototype.getSummary = function () {
     pos += ', ' + this.character;
   }
   return {
-    summary: pos + ': ' + this.message,
-    className: this.className
+    summary: '<span>' + pos + '</span>: ' + this.message,
+    rawSummary: true,
+    className: this.className,
+    handler: function (element) {
+      $('span', element)
+        .css('cursor', 'pointer')
+        .click(this.goToLine.bind(this));
+    }.bind(this)
   };
 };
 

--- a/lib/MessagePanelView.js
+++ b/lib/MessagePanelView.js
@@ -76,13 +76,25 @@ MessagePanelView.prototype.setTitle = function (title, raw) {
   }
 };
 
-MessagePanelView.prototype.setSummary = function (summary, className) {
+MessagePanelView.prototype.setSummary = function (summary) {
+  var
+    message = summary.summary,
+    className = summary.className,
+    raw = summary.rawSummary || false,
+    handler = summary.handler || undefined;
   // Reset the class-attributes on the old summary
   this.summary.attr('class', 'heading-summary inline-block');
   // Set the new summary
-  this.summary.text(summary);
+  if (raw) {
+    this.summary.html(message);
+  } else {
+    this.summary.text(message);
+  }
   if (className) {
     this.summary.addClass(className);
+  }
+  if (handler) {
+    handler(this.summary);
   }
 };
 
@@ -108,8 +120,7 @@ MessagePanelView.prototype.add = function (view) {
   if (this.messages.length === 0 && view.getSummary) {
     // This is the first message, so use it to
     // set the summary
-    var summary = view.getSummary();
-    this.setSummary(summary.summary, summary.className);
+    this.setSummary(view.getSummary());
   }
   this.messages.push(view);
   this.body.append(view);


### PR DESCRIPTION
Before the big API merge the "line errors" in foldmode worked just like "line errors" in unfold mode

`goToLine`
