### PR TITLE
just some cleanup to make jslint happy!

### DIFF
--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -47,7 +47,7 @@ LineMessageView.prototype.goToLine = function () {
     char = (this.character !== undefined) ? this.character - 1 : 0,
     activeFile,
     activeEditor =  atom.workspace.getActiveEditor();
-  if (activeEditor !== "undefined" && activeEditor !== null) {
+  if (activeEditor !== undefined && activeEditor !== null) {
     activeFile = Path.relative(atom.project.rootDirectory.path, activeEditor.getUri());
   }
 


### PR DESCRIPTION
and removing unnecessary typeof

```
if (typeof activeEditor !== "undefined" && activeEditor !== null) {
```
