### PR TITLE
Fix cursor position

### DIFF
--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -3,7 +3,6 @@
 var
   View = require('atom').View,
   inherits = require('./utils').inherits,
-  Path = require('path'),
   $ = require('atom').$;
 
 var LineMessageView = function (params) {
@@ -48,7 +47,7 @@ LineMessageView.prototype.goToLine = function () {
     activeFile,
     activeEditor =  atom.workspace.getActiveEditor();
   if (activeEditor !== undefined && activeEditor !== null) {
-    activeFile = Path.relative(atom.project.rootDirectory.path, activeEditor.getUri());
+    activeFile = atom.project.relativize(activeEditor.getUri());
   }
 
   if (this.file !== undefined && this.file !== activeFile) {


### PR DESCRIPTION
An Atom release or two ago, I noticed that the click-to-navigate functionality in [go-plus](https://github.com/joefitzgerald/go-plus) had stopped working properly. After some tracing around I narrowed the problem down to this.

The main issue was that `activeFile` was now being populated with some kind of path with `..` components, rather than the expected project-relative path. I found [a better method in the Project API](https://atom.io/docs/api/v0.125.0/Project#instance-relativize) for this.

While I was changing that, I also used [the Editor's `setCursorBufferPosition` method](https://atom.io/docs/api/v0.125.0/Editor#instance-setCursorBufferPosition) to reposition the cursor. This way, it'll behave a little more nicely with multiple cursors active, by consolidating them into one at the new location.
