### PR TITLE
Destroy surrounding panel element on close

### DIFF
--- a/lib/MessagePanelView.js
+++ b/lib/MessagePanelView.js
@@ -64,6 +64,10 @@ MessagePanelView.prototype.attach = function () {
 
 MessagePanelView.prototype.close = function () {
   this[this.closeMethod].call(this);
+
+  if(this.panel) {
+    this.panel.destroy();
+  }
 };
 
 MessagePanelView.prototype.initialize = function () {


### PR DESCRIPTION
Calling close() on the MessagePanelView only removes the inner div element, leaving the <atom-panel> element in the DOM. This leads to an ever growing message panel.
