### PR TITLE
fix deprecate api call (getActiveEditor->getActiveTextEditor)

### DIFF
--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -46,7 +46,7 @@ LineMessageView.prototype.goToLine = function () {
   var
     char = (this.character !== undefined) ? this.character - 1 : 0,
     activeFile,
-    activeEditor =  atom.workspace.getActiveEditor();
+    activeEditor =  atom.workspace.getActiveTextEditor();
   if (activeEditor !== undefined && activeEditor !== null) {
     activeFile = Path.relative(atom.project.rootDirectories[0].path, activeEditor.getURI());
   }


### PR DESCRIPTION
fix the https://github.com/joefitzgerald/go-plus/issues/196 issue