### PR TITLE
Atom commands to go to next/prev message

### DIFF
--- a/.jslintrc
+++ b/.jslintrc
@@ -1,8 +1,5 @@
 {
   "indent": 2,
   "node": true,
-  "predef": {
-		"atom": true,
-    "document": true
-	}
+  "predef": ["atom", "document"]
 }

--- a/lib/LineMessageView.js
+++ b/lib/LineMessageView.js
@@ -4,11 +4,12 @@ var
   View = require('space-pen').View,
   inherits = require('./utils').inherits,
   Path = require('path'),
+  Point = require('atom').Point,
   $ = require('space-pen').$;
 
 var LineMessageView = function (params) {
-  this.line = params.line;
-  this.character = params.character || undefined;
+  this.line = parseInt(params.line, 10);
+  this.character = params.character ? parseInt(params.character, 10) : undefined;
   this.file = params.file || undefined;
   this.message = params.message;
   this.preview = params.preview || undefined;
@@ -42,22 +43,35 @@ LineMessageView.content = function () {
   }.bind(this));
 };
 
-LineMessageView.prototype.goToLine = function () {
+LineMessageView.prototype.isHighlighted = function () {
+  return this.hasClass('highlight');
+};
+
+LineMessageView.prototype.getCursorPoint = function () {
   var
     char = (this.character !== undefined) ? this.character - 1 : 0,
+    line = this.line - 1;
+  return new Point(line, char);
+};
+
+LineMessageView.prototype.goToLine = function () {
+  var point = this.getCursorPoint(),
     activeFile,
-    activeEditor =  atom.workspace.getActiveTextEditor();
+    activeEditor = atom.workspace.getActiveTextEditor();
   if (activeEditor !== undefined && activeEditor !== null) {
     activeFile = Path.relative(atom.project.rootDirectories[0].path, activeEditor.getURI());
   }
 
   if (this.file !== undefined && this.file !== activeFile) {
     atom.workspace.open(this.file, {
-      initialLine: this.line - 1,
-      initialColumn: char
+      initialLine: point.row,
+      initialColumn: point.column
+    }).then(function (editor) {
+      editor.scrollToBufferPosition(point);
+      editor.setCursorBufferPosition(point);
     });
   } else {
-    atom.workspace.getActiveTextEditor().cursors[0].setBufferPosition([this.line - 1, char]);
+    atom.workspace.getActiveTextEditor().setCursorBufferPosition(point);
   }
 };
 

--- a/lib/MessageList.js
+++ b/lib/MessageList.js
@@ -1,0 +1,69 @@
+"use strict";
+
+function MessageList() {
+  this.messages = [];
+}
+
+var msgs = MessageList.prototype;
+
+msgs.clear = function () {
+  this.messages = [];
+};
+
+msgs.setCurrentMessage = function (msg) {
+  this.currentMessageIndex = this.messages.indexOf(msg);
+};
+
+msgs.nextMessage = function (offset) {
+  var n = this.currentMessageIndex, count = this.length;
+  if (n === undefined) {
+    n = (offset === 1 ? -1 : 0);
+  }
+  n += offset;
+  if (n < 0) {
+    n = count - (-n % count);
+  } else {
+    n = n % count;
+  }
+  this.currentMessageIndex = n;
+  return this.at(n);
+};
+
+msgs.at = function (index) {
+  return this.messages[index];
+};
+
+msgs.indexOf = function (thing) {
+  return this.messages.indexOf(thing);
+};
+
+msgs.push = function (msg) {
+  this.messages.push(msg);
+};
+
+msgs.empty = function () {
+  return this.messages.length === 0;
+};
+
+msgs.getHighlightedMessages = function () {
+  return this.messages.filter(function (msg) {
+    return msg.isHighlighted && msg.isHighlighted();
+  });
+};
+
+msgs.findMessagesAt = function (relativeFileURI, point) {
+  var pointLine = (point.row + 1);
+  return this.messages.filter(function (msg) {
+    return msg.line === pointLine && (!msg.file || msg.file === relativeFileURI);
+  });
+};
+
+Object.defineProperties(msgs, {
+  length: {
+    get: function () {
+      return this.messages.length;
+    }
+  }
+});
+
+module.exports = MessageList;

--- a/lib/MessagePanelView.js
+++ b/lib/MessagePanelView.js
@@ -2,8 +2,11 @@
 
 var
   $ = require('space-pen').$,
+  CompositeDisposable = require('atom').CompositeDisposable,
   View = require('space-pen').View,
-  inherits = require('./utils').inherits;
+  MessageList = require('./MessageList'),
+  inherits = require('./utils').inherits,
+  path = require('path');
 
 var MessagePanelView = function (params) {
   this.title = params.title;
@@ -15,7 +18,8 @@ var MessagePanelView = function (params) {
   this.closeMethod = params.closeMethod || 'hide';
   this.recentMessagesAtTop = params.recentMessagesAtTop || false;
   this.position = params.position || 'bottom';
-  this.messages = [];
+  this.messages = new MessageList();
+  this.disposables = new CompositeDisposable();
 
   View.apply(this, arguments);
 };
@@ -98,11 +102,118 @@ MessagePanelView.prototype.attach = function () {
   } else {
     this.panel.show();
   }
+
+  this.registerNavigationCommands();
+  this.registerCursorListeners();
+};
+
+MessagePanelView.prototype.getHighlightedMessages = function () {
+  return this.messages.getHighlightedMessages();
+};
+
+MessagePanelView.prototype.registerNavigationCommands = function () {
+  this.disposables.add(atom.commands.add('atom-workspace', {
+    'message-panel:next-message': this.visitNextMessage.bind(this),
+    'message-panel:previous-message': this.visitPreviousMessage.bind(this)
+  }));
+};
+
+MessagePanelView.prototype.registerCursorListeners = function () {
+  if (this.listenersRegistered) {
+    return;
+  }
+  this.disposables.add(atom.workspace.observeTextEditors(this.observeTextEditor.bind(this)));
+  this.listenersRegistered = true;
+};
+
+MessagePanelView.prototype.observeTextEditor = function (editor) {
+  this.disposables.add(editor.onDidChangeCursorPosition(function (e) {
+    return this.onDidChangeCursorPosition(editor, e);
+  }.bind(this)));
+};
+
+MessagePanelView.prototype.onDidChangeCursorPosition = function (editor, e) {
+  var projectRoot = atom.project && atom.project.getPaths()[0],
+    point = e.newBufferPosition,
+    relativeFileURI,
+    msgs,
+    ignored;
+
+  if (!projectRoot) {
+    return; // Don't even bother.
+  }
+
+  if (this.ignoreCursorToPoint) {
+    ignored = this.ignoreCursorToPoint;
+    delete this.ignoreCursorToPoint;
+    if (point.row === ignored.row && point.column === ignored.column) {
+      return;
+    }
+  }
+
+  relativeFileURI = path.relative(projectRoot, editor.getURI());
+  msgs = this.messages.findMessagesAt(relativeFileURI, point);
+  this.selectMessages(msgs);
+};
+
+MessagePanelView.prototype.visitNextMessage = function () {
+  return this.visitMessageAtOffset(1);
+};
+
+MessagePanelView.prototype.visitPreviousMessage = function () {
+  return this.visitMessageAtOffset(-1);
+};
+
+MessagePanelView.prototype.visitMessageAtOffset = function (offset) {
+  var message = this.messages.nextMessage(offset),
+    firstMessage = message;
+  while (message && !message.goToLine) {
+    message = this.messages.nextMessage(offset);
+    if (message === firstMessage) {
+      return undefined;
+    }
+  }
+  this.visitMessage(message);
+};
+
+MessagePanelView.prototype.visitMessage = function (message) {
+  if (message && message.goToLine) {
+    message.goToLine();
+    this.ignoreCursorToPoint = message.getCursorPoint();
+    this.selectMessages([message]);
+  }
+};
+
+MessagePanelView.prototype.selectMessages = function (messages) {
+  var i, length, firstMsg, msg;
+  if (!messages) {
+    return;
+  }
+  this.find('.line-message').removeClass('highlight');
+  for (i = 0, length = messages.length; i < length; i += 1) {
+    msg = messages[i];
+    msg.addClass('highlight');
+  }
+
+  firstMsg = messages[0];
+  if (firstMsg) {
+    this.messages.setCurrentMessage(firstMsg);
+    if (firstMsg[0]) {
+      firstMsg[0].scrollIntoView();
+    }
+  }
+};
+
+MessagePanelView.prototype.clearListeners = function () {
+  this.disposables.dispose();
+  this.disposables = new CompositeDisposable();
+  delete this.listenersRegistered;
 };
 
 MessagePanelView.prototype.close = function () {
+  this.clearListeners();
   if (this.panel !== undefined) {
-    this.panel[this.closeMethod].call(this.panel);
+    this.panel[this.closeMethod]();
     if (this.closeMethod === 'destroy') {
       this.panel = undefined;
     }
@@ -161,12 +272,12 @@ MessagePanelView.prototype.toggle = function () {
 };
 
 MessagePanelView.prototype.clear = function () {
-  this.messages = [];
+  this.messages.clear();
   this.body.empty();
 };
 
 MessagePanelView.prototype.add = function (view) {
-  if (this.messages.length === 0 && view.getSummary) {
+  if (this.messages.empty() && view.getSummary) {
     // This is the first message, so use it to
     // set the summary
     this.setSummary(view.getSummary());

--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   "dependencies": {
     "space-pen": "^4"
   },
+  "devDependencies": {
+    "temp": ">= 0.8.1",
+    "deep-equal": ">= 1.0.0"
+  },
   "homepage": "https://github.com/tcarlsen/atom-message-panel"
 }

--- a/spec/messagepanel-spec.coffee
+++ b/spec/messagepanel-spec.coffee
@@ -1,0 +1,199 @@
+temp = require('temp').track()
+{MessagePanelView, PlainMessageView, LineMessageView} = require '../lib'
+path = require 'path'
+deepEqual = require 'deep-equal'
+
+describe "MessagePanelView: message navigation", ->
+  projectRoot = temp.mkdirSync()
+  widgetContent = """
+                  widget first line Mark1
+                  widget second Mark2 line
+                  widget third
+                  widget fourth line Mark4A Mark4B
+                  """
+  gerbilContent = """
+                  gerbil first
+                  gerbil second
+                  gerbil third Mark3
+                  gerbil fourth
+                  gerbil Mark5 fifth
+                  """
+
+  editors = { }
+  [workspaceElement, messagePanel, widgetMarks, gerbilMarks] = []
+
+  triggerCommand = (command) ->
+    atom.commands.dispatch(workspaceElement, command)
+
+  nextMessage = -> triggerCommand('message-panel:next-message')
+  prevMessage = -> triggerCommand('message-panel:previous-message')
+
+  findEditor = (filename) ->
+    for editor in atom.workspace.getTextEditors()
+      return editor if path.relative(projectRoot, editor.getURI()) is filename
+
+  loadEditor = (name, text) ->
+    openedEditor = undefined
+    waitsForPromise ->
+      atom.workspace.open("zap/test.#{name}").then (e) ->
+        openedEditor = e
+        e.setText(text)
+    runs ->
+      editors[name] = openedEditor
+
+  loadMarks = (editor) ->
+    text = editor.getText()
+    markOffsets = []
+    index = -1
+    while (index = text.indexOf("Mark", index + 1)) != -1
+      markOffsets.push(index)
+
+    buffer = editor.getBuffer()
+    file = path.relative(projectRoot, editor.getURI())
+    for offset in markOffsets
+      pos = buffer.positionForCharacterIndex(offset)
+      new LineMessageView
+        file: file
+        line: pos.row + 1
+        character: pos.column + 1
+
+  cursorToText = (editor, findText) ->
+    text = editor.getText()
+    pos = text.indexOf(findText)
+    if pos != -1
+      editor.setCursorBufferPosition(
+        editor.getBuffer().positionForCharacterIndex(pos))
+    else
+      throw("Can't find #{findText} in #{editor.getURI()}")
+
+  cursorAt = (editor, message) ->
+    deepEqual(editor.getCursorBufferPosition(), message.getCursorPoint())
+
+  cursorAtHighlighted = (editor, message) ->
+    cursorAt(editor, message) and message.isHighlighted()
+
+  # Waits for the assertion to hold
+  waitExpects = (msg) ->
+    (fn, time=500) ->
+      waitsFor(fn, msg, time)
+      runs -> expect(fn()).toBe(true)
+
+  beforeEach ->
+    workspaceElement ?= atom.views.getView(atom.workspace)
+    atom.project.setPaths([projectRoot])
+    loadEditor('widget', widgetContent)
+    loadEditor('gerbil', gerbilContent)
+    runs ->
+      widgetMarks = loadMarks(editors.widget)
+      gerbilMarks = loadMarks(editors.gerbil)
+
+  beforeEach ->
+    messagePanel = new MessagePanelView
+      title: "Test panel"
+      closeMethod: 'destroy'
+    for mark in widgetMarks
+      messagePanel.add(mark)
+    messagePanel.add(
+      new PlainMessageView(message: "Spoiler; should be ignored"))
+    for mark in gerbilMarks
+      messagePanel.add(mark)
+    messagePanel.attach()
+
+  afterEach ->
+    messagePanel.close()
+
+  describe "message navigation using message-panel:next-message", ->
+    it "will visit the first mark on the first next-message command", ->
+      runs -> nextMessage()
+      waitExpects("cursor to first mark") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[0])
+
+    it "will cycle forward through messages", ->
+      runs -> nextMessage()
+      waitExpects("cursor to mark 1") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[0])
+      runs -> nextMessage()
+      waitExpects("cursor to mark 2") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[1])
+      runs -> nextMessage()
+      waitExpects("cursor to mark 3") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[2])
+
+    it ("will jump to the next file when the current message " +
+        "is the last in the current file"), ->
+      runs ->
+        editors.widget.setCursorBufferPosition(
+          widgetMarks[widgetMarks.length - 1].getCursorPoint())
+      # Moving cursor to the line should have selected the *first* message on
+      # that line, so trigger nextMessage() twice
+      runs -> nextMessage()
+      waitExpects("cursor to last mark") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[widgetMarks.length - 1])
+      runs -> nextMessage()
+      waitExpects("gerbil editor active") ->
+        atom.workspace.getActiveTextEditor() == editors.gerbil
+      waitExpects("cursor at first gerbil mark") ->
+        cursorAtHighlighted(editors.gerbil, gerbilMarks[0])
+
+    it "will wrap back to the first message when advancing from the last", ->
+      runs ->
+        editors.gerbil.setCursorBufferPosition(
+          gerbilMarks[gerbilMarks.length - 1].getCursorPoint())
+      runs -> nextMessage()
+      waitExpects("widget editor active") ->
+        atom.workspace.getActiveTextEditor() == editors.widget
+      waitExpects("cursor at first widget mark") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[0])
+
+  describe "message navigation using message-panel:previous-message", ->
+    it "will visit the last mark on the first previous-message command", ->
+      prevMessage()
+      waitExpects("cursor at last gerbil mark") ->
+        cursorAtHighlighted(editors.gerbil, gerbilMarks[gerbilMarks.length - 1])
+
+    it "will cycle backward through messages", ->
+      runs -> prevMessage()
+      waitExpects("cursor at last gerbil mark") ->
+        cursorAtHighlighted(editors.gerbil, gerbilMarks[gerbilMarks.length - 1])
+      runs -> prevMessage()
+      waitExpects("cursor at last-1 gerbil mark") ->
+        cursorAtHighlighted(editors.gerbil, gerbilMarks[gerbilMarks.length - 2])
+      runs -> prevMessage()
+      waitExpects("cursor at last widget mark") ->
+        atom.workspace.getActiveTextEditor() == editors.widget and
+        cursorAtHighlighted(editors.widget, widgetMarks[widgetMarks.length - 1])
+
+    it "will jump to the previous file when at the first message", ->
+      runs ->
+        editors.gerbil.setCursorBufferPosition(
+          gerbilMarks[0].getCursorPoint())
+      runs -> prevMessage()
+      waitExpects("cursor at last widget mark") ->
+        cursorAtHighlighted(editors.widget, widgetMarks[widgetMarks.length - 1])
+
+  describe "highlight on manual navigation", ->
+    it "will highlight a message when the cursor is on the same line", ->
+      runs -> editors.widget.setCursorBufferPosition([0, 0])
+      waitExpects("first message to be highlighted") ->
+        highlighted = messagePanel.getHighlightedMessages()
+        highlighted.length == 1 && highlighted[0] == widgetMarks[0]
+
+    it "will highlight all messages on the line with the cursor", ->
+      runs ->
+        editors.widget.setCursorBufferPosition(
+          widgetMarks[widgetMarks.length - 1].getCursorPoint())
+      waitExpects("last two messages to be highlighted") ->
+        deepEqual(messagePanel.getHighlightedMessages(),
+                  widgetMarks.slice(widgetMarks.length - 2))
+
+    it "will clear highlights when the cursor is on a line with no messages", ->
+      runs ->
+        editors.widget.setCursorBufferPosition(
+          widgetMarks[widgetMarks.length - 1].getCursorPoint())
+      waitExpects("last two messages to be highlighted") ->
+        deepEqual(messagePanel.getHighlightedMessages(),
+                  widgetMarks.slice(widgetMarks.length - 2))
+      runs ->
+        cursorToText(editors.widget, "widget third")
+      waitExpects("no messages to be highlighted") ->
+        messagePanel.getHighlightedMessages().length == 0


### PR DESCRIPTION
This is handy when the message pane is used for error/warning messages.

This commit does two things:

- Adds atom commands "message-panel:next-message" and
  "message-panel:previous-message" to go to the previous and next messages.
  The active message panel keeps track of the current message.
  The *last attached* message panel responds to these commands.

<img width="964" alt="add next and previous message commands" src="https://cloud.githubusercontent.com/assets/331814/9722781/079d7dd8-5582-11e5-9b59-1cfe5d3f8f2a.png">
The screenshot shows my local keybindings from `~/.atom/keymap.cson`. The new commands have no default keybindings (although any Atom extension that *uses* AMP may choose to assign default keybindings).

- Highlights messages when the editor cursor moves to the line mentioned in the
  message(s).

<img width="964" alt="highlights messages on current line" src="https://cloud.githubusercontent.com/assets/331814/9722786/0cdcaf9e-5582-11e5-9fce-c6ed94beabca.png">

I had to tweak .jslintrc to run with the current jslint (it was unclear what jslint version the existing .jslintrc was for).